### PR TITLE
Fix Windows path bug - Use uri.fsPath to support Windows and UNC paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,17 @@
 // Place your settings in this file to overwrite default and user settings.
 {
     "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/.vscode-test/*/**": true,
+        "**/node_modules/*/**": true,
+        "**/out/*/**": true
     },
     "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
+        "**/.git": true,
+        "**/.vscode-test": true,
+        "**/node_modules": true,
+        "**/out": true
     },
     "editor.rulers": [80]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2019-08-18
+
+### Fixed
+-   Fix windows file path recognition.
+
 ## [1.2.0] - 2019-08-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "testify",
-    "version": "1.1.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testify",
   "displayName": "Testify",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "felixjb"
   },

--- a/src/commands/debugTestCommand.ts
+++ b/src/commands/debugTestCommand.ts
@@ -8,7 +8,7 @@ async function debugTest(
   fileName: string,
   testName: string
 ) {
-  const relativeFilename = relative(rootPath.uri.path, fileName);
+  const relativeFilename = relative(rootPath.uri.fsPath, fileName);
   const testRunner = await getTestRunner(rootPath);
 
   testRunner.debugTest(rootPath, relativeFilename, testName);

--- a/src/commands/runTestCommand.ts
+++ b/src/commands/runTestCommand.ts
@@ -8,7 +8,7 @@ async function runTest(
   fileName: string,
   testName: string
 ) {
-  const relativeFilename = relative(rootPath.uri.path, fileName);
+  const relativeFilename = relative(rootPath.uri.fsPath, fileName);
   const testRunner = await getTestRunner(rootPath);
 
   testRunner.runTest(rootPath, relativeFilename, testName);

--- a/src/providers/TerminalProvider.ts
+++ b/src/providers/TerminalProvider.ts
@@ -12,7 +12,7 @@ export class TerminalProvider {
     }
 
     this.activeTerminal = window.createTerminal(terminalOptions);
-    this.activeTerminal.sendText(`cd ${rootPath.uri.path}`, true);
+    this.activeTerminal.sendText(`cd ${rootPath.uri.fsPath}`, true);
 
     return this.activeTerminal;
   }

--- a/src/runners/TestRunnerFactory.ts
+++ b/src/runners/TestRunnerFactory.ts
@@ -24,7 +24,7 @@ async function getAvailableTestRunner(
 ): Promise<ITestRunnerInterface> {
   for (const runner of testRunners) {
     const doesRunnerExist = await doesFileExist(
-      join(rootPath.uri.path, runner.binPath)
+      join(rootPath.uri.fsPath, runner.binPath)
     );
 
     if (doesRunnerExist) {


### PR DESCRIPTION
### Description

Use `uri.fsPath` to support Windows and UNC paths.

### Related issue(s)

Fixes [# 7](https://github.com/g3offrey/javascript-test-runner/issues/7)

### Documentation

No functionality behavior was changed.