### PR TITLE
Add the "testRunnerPath" configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2019-09-08
+
+### Added
+
+-   Add `testRunnerPath` configuration.
+
 ## [1.2.1] - 2019-08-18
 
 ### Fixed
+
 -   Fix windows file path recognition.
 
 ### Changed
+
 -   Update `skipFile` configuration to use new VSCode's string arrays format.
 
 ## [1.2.0] - 2019-08-10
 
 ### Added
+
 -   Add `skipFile` configuration (a.k.a. "Not My Code" feature).
 
 ## [1.1.0] - 2019-06-24
 
 ### Added
+
 -   Add support to tests with spread operator `(...)`.
 
 ## [1.0.0] - 2019-06-21

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Currently it works **out of the box** for **Mocha** and **Jest** test runner.
 
 The following configuration properties are available:
 
-| Property                 | Description                                        | Example                      |
-| ------------------------ | -------------------------------------------------- | ---------------------------- |
-| `testify.additionalArgs` | CLI args to pass to test runner                    | "--watch"                    |
-| `testify.envVars`        | Environment variables to set before running a test | { "NODE_ENV": "test" }       |
-| `testify.skipFiles`      | Array of glob patterns for script paths to skip    | ["<node_internals>/**/*.js"] |
+| Property                 | Description                                        | Example                       |
+| ------------------------ | -------------------------------------------------- | ----------------------------- |
+| `testify.additionalArgs` | CLI args to pass to test runner                    | "--watch"                     |
+| `testify.envVars`        | Environment variables to set before running a test | { "NODE_ENV": "test" }        |
+| `testify.skipFiles`      | Array of glob patterns for script paths to skip    | ["<node_internals>/**/*.js"]  |
+| `testify.testRunnerPath` | Path to test runner                                | "src/node_modules/.bin/mocha" |
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
+[![Build Status](https://travis-ci.com/felixjb/testify.svg?branch=master)](https://travis-ci.com/felixjb/testify)
+
 # Testify
 
-[![Build Status](https://travis-ci.com/felixjb/testify.svg?branch=master)](https://travis-ci.com/felixjb/testify)
+<p align="center">
+    <a title="Run JavaScript & TypeScript tests easily using CodeLens" href="https://marketplace.visualstudio.com/items?itemName=felixjb.testify">
+        <img src="resources/icon.png" alt="Testify"/>
+    </a>
+</p>
 
 Testify is a JavaScript and Typescript test runner extension for VSCode. It adds codelens near `describe`, `it`, and `test` keywords enabling VSCode to run associated tests and output the results in the integrated terminal.
 Currently it works **out of the box** for **Mocha** and **Jest** test runner.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
     <a title="Run JavaScript & TypeScript tests easily using CodeLens" href="https://marketplace.visualstudio.com/items?itemName=felixjb.testify">
-        <img src="resources/icon.png" alt="Testify"/>
+        <img src="https://raw.githubusercontent.com/felixjb/testify/master/resources/icon.png" alt="Testify"/>
     </a>
 </p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "testify",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testify",
   "displayName": "Testify",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "felixjb"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test",
     "unit"
   ],
-  "preview": true,
   "icon": "resources/icon.png",
   "main": "./out/extension",
   "activationEvents": [
@@ -49,27 +48,33 @@
       {
         "properties": {
           "testify.additionalArgs": {
-            "type": "string",
             "default": "",
             "description": "CLI args to pass to test runner.",
-            "scope": "resource"
+            "scope": "resource",
+            "type": "string"
           },
           "testify.envVars": {
-            "type": "object",
             "default": {
               "NODE_ENV": "test"
             },
             "description": "Environment variables to set before running a test.",
-            "scope": "resource"
+            "scope": "resource",
+            "type": "object"
           },
           "testify.skipFiles": {
-            "type": "array",
+            "default": [],
+            "description": "Array of glob patterns for script paths to skip.",
             "items": {
               "type": "string"
             },
-            "default": [],
-            "description": "Array of glob patterns for script paths to skip.",
-            "scope": "resource"
+            "scope": "resource",
+            "type": "array"
+          },
+          "testify.testRunnerPath": {
+            "default": "",
+            "description": "Path to test runner.",
+            "scope": "resource",
+            "type": "string"
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import { commands, ExtensionContext, languages } from "vscode";
-
 import debugTestCommand from "./commands/debugTestCommand";
 import runTestCommand from "./commands/runTestCommand";
 import FILE_SELECTOR from "./constants/fileSelector";

--- a/src/interfaces/ITestRunnerInterface.ts
+++ b/src/interfaces/ITestRunnerInterface.ts
@@ -1,11 +1,10 @@
 import { WorkspaceFolder } from "vscode";
-
 import { ConfigurationProvider } from "../providers/ConfigurationProvider";
 import { TerminalProvider } from "../providers/TerminalProvider";
 
 export interface ITestRunnerInterface {
   name: string;
-  binPath: string;
+  path: string;
   terminalProvider: TerminalProvider;
   configurationProvider: ConfigurationProvider;
 

--- a/src/interfaces/ITestRunnerOptions.ts
+++ b/src/interfaces/ITestRunnerOptions.ts
@@ -1,7 +1,0 @@
-import { ConfigurationProvider } from "../providers/ConfigurationProvider";
-import { TerminalProvider } from "../providers/TerminalProvider";
-
-export interface ITestRunnerOptions {
-  terminalProvider: TerminalProvider;
-  configurationProvider: ConfigurationProvider;
-}

--- a/src/providers/ConfigurationProvider.ts
+++ b/src/providers/ConfigurationProvider.ts
@@ -18,4 +18,8 @@ export class ConfigurationProvider {
   get skipFiles(): string[] {
     return this.configuration.get("skipFiles");
   }
+
+  get testRunnerPath(): string {
+    return this.configuration.get("testRunnerPath");
+  }
 }

--- a/src/runners/JestTestRunner.ts
+++ b/src/runners/JestTestRunner.ts
@@ -1,23 +1,27 @@
 import { join } from "path";
 import { debug, WorkspaceFolder } from "vscode";
-
 import { ITestRunnerInterface } from "../interfaces/ITestRunnerInterface";
-import { ITestRunnerOptions } from "../interfaces/ITestRunnerOptions";
 import { ConfigurationProvider } from "../providers/ConfigurationProvider";
 import { TerminalProvider } from "../providers/TerminalProvider";
 
+// TODO: Make a more generic test runner class and extend it
 export class JestTestRunner implements ITestRunnerInterface {
   public name: string = "jest";
+  public path: string = join("node_modules", this.name, "bin", this.name);
   public terminalProvider: TerminalProvider = null;
   public configurationProvider: ConfigurationProvider = null;
 
-  get binPath(): string {
-    return join("node_modules", ".bin", "jest");
-  }
-
-  constructor({ terminalProvider, configurationProvider }: ITestRunnerOptions) {
+  constructor(
+    configurationProvider: ConfigurationProvider,
+    terminalProvider: TerminalProvider,
+    path?: string
+  ) {
     this.terminalProvider = terminalProvider;
     this.configurationProvider = configurationProvider;
+
+    if (path) {
+      this.path = path;
+    }
   }
 
   public runTest(
@@ -28,12 +32,10 @@ export class JestTestRunner implements ITestRunnerInterface {
     const additionalArguments = this.configurationProvider.additionalArguments;
     const environmentVariables = this.configurationProvider
       .environmentVariables;
-    // We force slash instead of backslash for Windows
-    const cleanedFileName = fileName.replace(/\\/g, "/");
 
-    const command = `${
-      this.binPath
-    } ${cleanedFileName} --testNamePattern="${testName}" ${additionalArguments}`;
+    const command = `${this.path} ${this.transformFileName(
+      fileName
+    )} --testNamePattern="${testName}" ${additionalArguments}`;
 
     const terminal = this.terminalProvider.get(
       { env: environmentVariables },
@@ -54,12 +56,9 @@ export class JestTestRunner implements ITestRunnerInterface {
       .environmentVariables;
     const skipFiles = this.configurationProvider.skipFiles;
 
-    // We force slash instead of backslash for Windows
-    const cleanedFileName = fileName.replace(/\\/g, "/");
-
     debug.startDebugging(rootPath, {
       args: [
-        cleanedFileName,
+        this.transformFileName(fileName),
         `--testNamePattern`,
         testName,
         "--runInBand",
@@ -68,13 +67,15 @@ export class JestTestRunner implements ITestRunnerInterface {
       console: "integratedTerminal",
       env: environmentVariables,
       name: "Debug Test",
-      program: "${workspaceFolder}/node_modules/.bin/jest",
+      program: join(rootPath.uri.fsPath, this.path),
       request: "launch",
       skipFiles,
-      type: "node",
-      windows: {
-        program: "${workspaceFolder}/node_modules/jest/bin/jest"
-      }
+      type: "node"
     });
+  }
+
+  // We force slash instead of backslash for Windows
+  private transformFileName(fileName: string) {
+    return fileName.replace(/\\/g, "/");
   }
 }

--- a/src/runners/MochaTestRunner.ts
+++ b/src/runners/MochaTestRunner.ts
@@ -1,23 +1,27 @@
 import { join } from "path";
 import { debug, WorkspaceFolder } from "vscode";
-
 import { ITestRunnerInterface } from "../interfaces/ITestRunnerInterface";
-import { ITestRunnerOptions } from "../interfaces/ITestRunnerOptions";
 import { ConfigurationProvider } from "../providers/ConfigurationProvider";
 import { TerminalProvider } from "../providers/TerminalProvider";
 
+// TODO: Make a more generic test runner class and extend it
 export class MochaTestRunner implements ITestRunnerInterface {
   public name: string = "mocha";
+  public path: string = join("node_modules", this.name, "bin", this.name);
   public terminalProvider: TerminalProvider = null;
   public configurationProvider: ConfigurationProvider = null;
 
-  get binPath(): string {
-    return join("node_modules", ".bin", "mocha");
-  }
-
-  constructor({ terminalProvider, configurationProvider }: ITestRunnerOptions) {
+  constructor(
+    configurationProvider: ConfigurationProvider,
+    terminalProvider: TerminalProvider,
+    path?: string
+  ) {
     this.terminalProvider = terminalProvider;
     this.configurationProvider = configurationProvider;
+
+    if (path) {
+      this.path = path;
+    }
   }
 
   public runTest(
@@ -30,7 +34,7 @@ export class MochaTestRunner implements ITestRunnerInterface {
       .environmentVariables;
 
     const command = `${
-      this.binPath
+      this.path
     } ${fileName} --grep="${testName}" ${additionalArguments}`;
 
     const terminal = this.terminalProvider.get(
@@ -63,13 +67,10 @@ export class MochaTestRunner implements ITestRunnerInterface {
       console: "integratedTerminal",
       env: environmentVariables,
       name: "Debug Test",
-      program: "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      program: join(rootPath.uri.fsPath, this.path),
       request: "launch",
       skipFiles,
-      type: "node",
-      windows: {
-        program: "${workspaceFolder}/node_modules/mocha/bin/_mocha"
-      }
+      type: "node"
     });
   }
 }

--- a/src/runners/TestRunnerFactory.ts
+++ b/src/runners/TestRunnerFactory.ts
@@ -1,14 +1,13 @@
-import { exists } from "fs";
-import { join } from "path";
-import { WorkspaceFolder } from "vscode";
+// TODO: This file looks odd. Refactor it as a proper factory
 
+import { exists } from "fs";
+import { basename, join } from "path";
+import { WorkspaceFolder } from "vscode";
 import { ITestRunnerInterface } from "../interfaces/ITestRunnerInterface";
 import { ConfigurationProvider } from "../providers/ConfigurationProvider";
 import { TerminalProvider } from "../providers/TerminalProvider";
 import { JestTestRunner } from "./JestTestRunner";
 import { MochaTestRunner } from "./MochaTestRunner";
-
-const terminalProvider = new TerminalProvider();
 
 function doesFileExist(filePath: string): Promise<boolean> {
   return new Promise(resolve => {
@@ -18,13 +17,30 @@ function doesFileExist(filePath: string): Promise<boolean> {
   });
 }
 
+async function getCustomTestRunnerName(
+  rootPath: WorkspaceFolder,
+  customTestRunnerPath: string
+): Promise<string> {
+  const doesExecutableExist = await doesFileExist(
+    join(rootPath.uri.fsPath, customTestRunnerPath)
+  );
+
+  if (doesExecutableExist) {
+    return basename(customTestRunnerPath)
+      .replace("_", "")
+      .toLowerCase();
+  }
+
+  throw new Error("No test runner in specified path. Please verify it.");
+}
+
 async function getAvailableTestRunner(
   testRunners: ITestRunnerInterface[],
   rootPath: WorkspaceFolder
 ): Promise<ITestRunnerInterface> {
   for (const runner of testRunners) {
     const doesRunnerExist = await doesFileExist(
-      join(rootPath.uri.fsPath, runner.binPath)
+      join(rootPath.uri.fsPath, runner.path)
     );
 
     if (doesRunnerExist) {
@@ -38,16 +54,39 @@ async function getAvailableTestRunner(
 export async function getTestRunner(
   rootPath: WorkspaceFolder
 ): Promise<ITestRunnerInterface> {
+  const terminalProvider = new TerminalProvider();
   const configurationProvider = new ConfigurationProvider(rootPath);
+  const customTestRunnerPath = configurationProvider.testRunnerPath;
 
-  const jestTestRunner = new JestTestRunner({
+  if (customTestRunnerPath) {
+    const customTestRunnerName = await getCustomTestRunnerName(
+      rootPath,
+      customTestRunnerPath
+    );
+
+    if (customTestRunnerName === "jest") {
+      return new JestTestRunner(
+        configurationProvider,
+        terminalProvider,
+        customTestRunnerPath
+      );
+    } else if (customTestRunnerName === "mocha") {
+      return new MochaTestRunner(
+        configurationProvider,
+        terminalProvider,
+        customTestRunnerPath
+      );
+    }
+  }
+
+  const jestTestRunner = new JestTestRunner(
     configurationProvider,
     terminalProvider
-  });
-  const mochaTestRunner = new MochaTestRunner({
+  );
+  const mochaTestRunner = new MochaTestRunner(
     configurationProvider,
     terminalProvider
-  });
+  );
 
   return getAvailableTestRunner([jestTestRunner, mochaTestRunner], rootPath);
 }


### PR DESCRIPTION
### Description

Add the `testRunnerPath` configuration to allow the user to specify a non default path to the Mocha or Jest executable

### Related issue(s)

Closes #9 

### Documentation

New configuration is described in the README file