### PR TITLE
Add codelens near mocha keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2019-09-27
+
+### Fixed
+
+-   Fix integrated terminal instances bug.
+
+### Added
+
+-   Add `suite`, `context` and `specify` keywords to test token list.
+
 ## [1.3.0] - 2019-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@
     </a>
 </p>
 
-Testify is a JavaScript and Typescript test runner extension for VSCode. It adds codelens near `describe`, `it`, and `test` keywords enabling VSCode to run associated tests and output the results in the integrated terminal.
+Testify is a JavaScript and Typescript test runner extension for VSCode. It adds codelens near the framework's keywords, such as
+- `suite`,
+- `describe`,
+- `context`,
+- `it`,
+- `specify`
+- `test`
+
+enabling VSCode to run associated tests and output the results in the integrated terminal.
 Currently it works **out of the box** for **Mocha** and **Jest** test runner.
 
 ## Demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "testify",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testify",
   "displayName": "Testify",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "felixjb"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "felixjb"
   },
   "publisher": "felixjb",
-  "description": "Run JavaScript tests easily using CodeLens",
+  "description": "Run JavaScript & TypeScript tests easily using CodeLens",
   "license": "MIT",
   "categories": [
     "Other"

--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -1,6 +1,6 @@
 import { parse, ParserOptions } from "@babel/parser";
 
-const testTokens = ["describe", "it", "test"];
+const testTokens = ["suite", "describe", "context", "it", "specify", "test"];
 
 function codeParser(sourceCode) {
   const parserOptions: ParserOptions = {

--- a/src/runners/TestRunnerFactory.ts
+++ b/src/runners/TestRunnerFactory.ts
@@ -9,6 +9,8 @@ import { TerminalProvider } from "../providers/TerminalProvider";
 import { JestTestRunner } from "./JestTestRunner";
 import { MochaTestRunner } from "./MochaTestRunner";
 
+const terminalProvider = new TerminalProvider();
+
 function doesFileExist(filePath: string): Promise<boolean> {
   return new Promise(resolve => {
     exists(filePath, doesExist => {
@@ -54,7 +56,6 @@ async function getAvailableTestRunner(
 export async function getTestRunner(
   rootPath: WorkspaceFolder
 ): Promise<ITestRunnerInterface> {
-  const terminalProvider = new TerminalProvider();
   const configurationProvider = new ConfigurationProvider(rootPath);
   const customTestRunnerPath = configurationProvider.testRunnerPath;
 


### PR DESCRIPTION
### Description

- Add mocha keywords (suite, context and specify) to test token list
- Fixes integrated terminal bug that created a new instance every time a test was executed

### Related issue(s)

This PR resolves #41 
