### PR TITLE
Fix: Mocha configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2019-05-13
+
+### Fixed
+
+-   Fix Mocha test filter option.
+-   Fix Mocha debug options.
+
 ## [1.4.0] - 2019-09-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "testify",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testify",
   "displayName": "Testify",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "felixjb"
   },

--- a/src/runners/MochaTestRunner.ts
+++ b/src/runners/MochaTestRunner.ts
@@ -35,7 +35,7 @@ export class MochaTestRunner implements ITestRunnerInterface {
 
     const command = `${
       this.path
-    } ${fileName} --grep="${testName}" ${additionalArguments}`;
+    } ${fileName} --fgrep="${testName}" ${additionalArguments}`;
 
     const terminal = this.terminalProvider.get(
       { env: environmentVariables },
@@ -57,13 +57,7 @@ export class MochaTestRunner implements ITestRunnerInterface {
     const skipFiles = this.configurationProvider.skipFiles;
 
     debug.startDebugging(rootPath, {
-      args: [
-        fileName,
-        "--grep",
-        testName,
-        "--no-timeout",
-        ...additionalArguments.split(" ")
-      ],
+      args: [fileName, "--fgrep", testName, ...additionalArguments.split(" ")],
       console: "integratedTerminal",
       env: environmentVariables,
       name: "Debug Test",


### PR DESCRIPTION
### Description
- Change Mocha test filters to use `fgrep` instead of `grep`
- Remove from Mocha the `timeout` option hardcoded in debug configuration

### Tests
N/A

### Documentation
N/A
