### PR TITLE
Only activate for defined test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This extension works currently with :
 
 -   Mocha
 -   Jest
+-   AVA
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testify",
   "displayName": "Testify",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "felixjb"
   },
@@ -15,7 +15,8 @@
     "mocha",
     "jest",
     "test",
-    "unit"
+    "unit",
+    "ava"
   ],
   "preview": false,
   "icon": "resources/icon.png",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,12 @@
             "description": "Path to test runner.",
             "scope": "resource",
             "type": "string"
+          },
+          "testify.testFilePattern": {
+            "default": "**/test/**/*.{js,ts,jsx,tsx}",
+            "description": "Testify will only activate when an open file matches the above pattern, defaults to all files inside a 'test' directory.",
+            "scope": "resource",
+            "type": "string"
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,53 @@
-import { commands, ExtensionContext, languages } from "vscode";
+import { commands, ExtensionContext, languages, workspace } from "vscode";
+import { ConfigurationProvider } from "./providers/ConfigurationProvider";
 import debugTestCommand from "./commands/debugTestCommand";
 import runTestCommand from "./commands/runTestCommand";
-import FILE_SELECTOR from "./constants/fileSelector";
 import TestRunnerCodeLensProvider from "./providers/TestRunnerCodeLensProvider";
 
 export function activate(context: ExtensionContext) {
-  context.subscriptions.push(
-    languages.registerCodeLensProvider(
-      FILE_SELECTOR,
+  function createCodeLensSubscription(fileSelector) {
+    if (!fileSelector) {
+      return;
+    }
+
+    return languages.registerCodeLensProvider(
+      fileSelector,
       new TestRunnerCodeLensProvider()
-    )
-  );
+    );
+  }
+
+  let codeLensSubscription = createCodeLensSubscription(getExecutionContext());
+
+  if (!codeLensSubscription) {
+    return;
+  } // If the current vscode context has no open folder
+  context.subscriptions.push(codeLensSubscription);
 
   commands.registerCommand("testify.run.test", runTestCommand);
   commands.registerCommand("testify.debug.test", debugTestCommand);
+
+  workspace.onDidChangeConfiguration(() => {
+    codeLensSubscription.dispose();
+    codeLensSubscription = createCodeLensSubscription(getExecutionContext());
+    context.subscriptions.push();
+  });
+}
+
+function getExecutionContext() {
+  const x = workspace.workspaceFolders;
+  if (!x) {
+    return;
+  }
+
+  const { configuration } = new ConfigurationProvider(
+    workspace.workspaceFolders[0]
+  );
+  const pattern = configuration.testFilePattern;
+
+  return [
+    {
+      pattern,
+      scheme: "file"
+    }
+  ];
 }

--- a/src/providers/ConfigurationProvider.ts
+++ b/src/providers/ConfigurationProvider.ts
@@ -22,4 +22,8 @@ export class ConfigurationProvider {
   get testRunnerPath(): string {
     return this.configuration.get("testRunnerPath");
   }
+
+  get testFilePattern(): string {
+    return this.configuration.get("testRunnerPath");
+  }
 }

--- a/src/runners/AvaTestRunner.ts
+++ b/src/runners/AvaTestRunner.ts
@@ -68,7 +68,7 @@ export class AvaTestRunner implements ITestRunnerInterface {
         "--break",
         "--serial",
         this.transformFileName(fileName),
-        `--match ${testName}`,
+        `--match="${testName}"`,
         ...additionalArguments.split(" ")
       ],
       runtimeExecutable: join(rootPath.uri.fsPath, this.path),

--- a/src/runners/AvaTestRunner.ts
+++ b/src/runners/AvaTestRunner.ts
@@ -51,24 +51,27 @@ export class AvaTestRunner implements ITestRunnerInterface {
     fileName: string,
     testName: string
   ) {
-    // const additionalArguments = this.configurationProvider.additionalArguments;
+    const additionalArguments = this.configurationProvider.additionalArguments;
     const environmentVariables = this.configurationProvider
       .environmentVariables;
     const skipFiles = this.configurationProvider.skipFiles;
 
     debug.startDebugging(rootPath, {
-      args: [
-        this.transformFileName(fileName),
-        `--debug`,
-        testName
-        // "--runInBand",
-        // ...additionalArguments.split(" ")
-      ],
       console: "integratedTerminal",
       env: environmentVariables,
       name: "Debug Test",
-      program: join(rootPath.uri.fsPath, this.path),
+      outputCapture: "std",
+      port: 9229,
       request: "launch",
+      runtimeArgs: [
+        "debug",
+        "--break",
+        "--serial",
+        this.transformFileName(fileName),
+        `--match ${testName}`,
+        ...additionalArguments.split(" ")
+      ],
+      runtimeExecutable: join(rootPath.uri.fsPath, this.path),
       skipFiles,
       type: "node"
     });

--- a/src/runners/AvaTestRunner.ts
+++ b/src/runners/AvaTestRunner.ts
@@ -1,0 +1,81 @@
+import { join } from "path";
+import { debug, WorkspaceFolder } from "vscode";
+import { ITestRunnerInterface } from "../interfaces/ITestRunnerInterface";
+import { ConfigurationProvider } from "../providers/ConfigurationProvider";
+import { TerminalProvider } from "../providers/TerminalProvider";
+
+// TODO: Make a more generic test runner class and extend it
+export class AvaTestRunner implements ITestRunnerInterface {
+  public name: string = "ava";
+  public path: string = join("node_modules", ".bin", this.name);
+  public terminalProvider: TerminalProvider = null;
+  public configurationProvider: ConfigurationProvider = null;
+
+  constructor(
+    configurationProvider: ConfigurationProvider,
+    terminalProvider: TerminalProvider,
+    path?: string
+  ) {
+    this.terminalProvider = terminalProvider;
+    this.configurationProvider = configurationProvider;
+
+    if (path) {
+      this.path = path;
+    }
+  }
+
+  public runTest(
+    rootPath: WorkspaceFolder,
+    fileName: string,
+    testName: string
+  ) {
+    const additionalArguments = this.configurationProvider.additionalArguments;
+    const environmentVariables = this.configurationProvider
+      .environmentVariables;
+
+    const command = `${this.path} ${this.transformFileName(
+      fileName
+    )} -m "${testName}" ${additionalArguments}`;
+
+    const terminal = this.terminalProvider.get(
+      { env: environmentVariables },
+      rootPath
+    );
+
+    terminal.sendText(command, true);
+    terminal.show(true);
+  }
+
+  public debugTest(
+    rootPath: WorkspaceFolder,
+    fileName: string,
+    testName: string
+  ) {
+    // const additionalArguments = this.configurationProvider.additionalArguments;
+    const environmentVariables = this.configurationProvider
+      .environmentVariables;
+    const skipFiles = this.configurationProvider.skipFiles;
+
+    debug.startDebugging(rootPath, {
+      args: [
+        this.transformFileName(fileName),
+        `--debug`,
+        testName
+        // "--runInBand",
+        // ...additionalArguments.split(" ")
+      ],
+      console: "integratedTerminal",
+      env: environmentVariables,
+      name: "Debug Test",
+      program: join(rootPath.uri.fsPath, this.path),
+      request: "launch",
+      skipFiles,
+      type: "node"
+    });
+  }
+
+  // We force slash instead of backslash for Windows
+  private transformFileName(fileName: string) {
+    return fileName.replace(/\\/g, "/");
+  }
+}

--- a/src/runners/TestRunnerFactory.ts
+++ b/src/runners/TestRunnerFactory.ts
@@ -6,6 +6,7 @@ import { WorkspaceFolder } from "vscode";
 import { ITestRunnerInterface } from "../interfaces/ITestRunnerInterface";
 import { ConfigurationProvider } from "../providers/ConfigurationProvider";
 import { TerminalProvider } from "../providers/TerminalProvider";
+import { AvaTestRunner } from "./AvaTestRunner";
 import { JestTestRunner } from "./JestTestRunner";
 import { MochaTestRunner } from "./MochaTestRunner";
 
@@ -77,6 +78,12 @@ export async function getTestRunner(
         terminalProvider,
         customTestRunnerPath
       );
+    } else if (customTestRunnerName === "ava") {
+      return new AvaTestRunner(
+        configurationProvider,
+        terminalProvider,
+        customTestRunnerPath
+      );
     }
   }
 
@@ -88,6 +95,13 @@ export async function getTestRunner(
     configurationProvider,
     terminalProvider
   );
+  const avaTestRunner = new AvaTestRunner(
+    configurationProvider,
+    terminalProvider
+  );
 
-  return getAvailableTestRunner([jestTestRunner, mochaTestRunner], rootPath);
+  return getAvailableTestRunner(
+    [jestTestRunner, mochaTestRunner, avaTestRunner],
+    rootPath
+  );
 }


### PR DESCRIPTION
- [ ] The code respects the linting rules 
**had to kill the tslint 'import-order' rule, I couldn't work out where it wanted me to put the file.**

### Related issue(s)

'fixes' #32  (workaround)

The issue is still present in any file that is considered (or configured) to be a 'test' file.

### Tests

There WAS a test for this issue that i had added, but now that the test detection has been deferred to the user, (*with a perfect default option of course...*) tests are irrelevant since detection should never even run on a file where the test is not intended.

### Documentation

Added the option `TestFilesPattern` to the configuration, which accepts a folder/file pattern and refreshes automatically when changed.

The default value `**/test/**/*.test.{js,ts,jsx,tsx}` will cause the extension to never activate on a file that is not somewhere in a 'test' folder and with the file extensions:
- `.test.js`
- `.test.ts`
- `.test.jsx`
- `.test.tsx`

## Notes for reviewer

This code is by no means final (see `extension.ts`) but it's late and i'm going to bed having achieved my goal of getting rid of the annoying codelens in places it should never even be scanning.