### PR TITLE
Enable optionalChaining and nullishCoalescing syntaxes

### DIFF
--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -4,7 +4,13 @@ const testTokens = ["suite", "describe", "context", "it", "specify", "test"];
 
 function codeParser(sourceCode) {
   const parserOptions: ParserOptions = {
-    plugins: ["jsx", "typescript", "objectRestSpread"],
+    plugins: [
+      "jsx",
+      "typescript",
+      "objectRestSpread",
+      "optionalChaining",
+      "nullishCoalescingOperator"
+    ],
     sourceType: "module",
     tokens: true
   };

--- a/src/test/parser/codeParser.test.ts
+++ b/src/test/parser/codeParser.test.ts
@@ -69,4 +69,43 @@ suite("codeParser Tests", () => {
       `;
     assert.equal(2, codeParser(code).length);
   });
+
+  test("Optional Chaining syntax", () => {
+    const code = `
+      describe("TestWithOptionalChaining", () => {
+        it("just works", () => {
+          type OptionalParams = {
+            name?: string;
+            catchphrase?: string;
+          }
+
+          const obj: OptionalParams = {
+            name: 'Testify',
+          };
+
+          const newObject = { ...obj };
+
+          expect(newObject?.name).to.be.equal('Testify');
+          expect(newObject?.catchphrase).toBeUndefined();
+        })
+      })`;
+
+    assert.equal(2, codeParser(code).length);
+  });
+
+  test("Nullish Coalescing syntax", () => {
+    const code = `
+      describe("TestWithNullishCoalescing", () => {
+        it("just works", () => {
+          const createUser = username => {
+            return username ?? 'No Name';
+          }
+
+          expect(createUser()).to.be.equal('No Name');
+          expect(createUser('silvawillian')).to.be.equal('silvawillian');
+        })
+      })`;
+
+    assert.equal(2, codeParser(code).length);
+  });
 });


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a pull request (PR)! 🎊

Please ensure your PR adheres to:
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] The code respects the linting rules
- [ ] It builds and passes all tests
- [ ] Sort by alphabetical order whenever possible
- and the following format...
-->

### Description

When writing some tests that uses TypeScript's new features (specially nullish coalescing and optional chaining), I've realized that I couldn't run the tests anymore, because the extension "deactivates".

This PR enables Babel's `nullishCoalescingOperator` and `optionalChaining`, making possible that tests that use those features may be able to run.

Probably this will also fix https://github.com/felixjb/testify/issues/54.

### Related issue(s)

https://github.com/felixjb/testify/issues/54

<!-- Thanks for contributing! -->
