### PR TITLE
feat: support decorators in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,88 +8,174 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
             "requires": {
                 "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/core": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-            "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+            "version": "7.12.9",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+            "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.4",
-                "@babel/helpers": "^7.4.4",
-                "@babel/parser": "^7.4.5",
-                "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.4.5",
-                "@babel/types": "^7.4.4",
-                "convert-source-map": "^1.1.0",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.12.5",
+                "@babel/helper-module-transforms": "^7.12.1",
+                "@babel/helpers": "^7.12.5",
+                "@babel/parser": "^7.12.7",
+                "@babel/template": "^7.12.7",
+                "@babel/traverse": "^7.12.9",
+                "@babel/types": "^7.12.7",
+                "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
-                "json5": "^2.1.0",
-                "lodash": "^4.17.11",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.2",
+                "lodash": "^4.17.19",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                }
             }
         },
         "@babel/generator": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-            "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+            "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
             "requires": {
-                "@babel/types": "^7.4.4",
+                "@babel/types": "^7.12.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.11",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+            "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+            "requires": {
+                "@babel/types": "^7.12.7"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+            "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+            "requires": {
+                "@babel/types": "^7.12.5"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+            "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.12.1",
+                "@babel/helper-replace-supers": "^7.12.1",
+                "@babel/helper-simple-access": "^7.12.1",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1",
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+            "integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
+            "requires": {
+                "@babel/types": "^7.12.7"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+            "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
-        "@babel/helper-split-export-declaration": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-replace-supers": {
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+            "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
             "requires": {
-                "@babel/types": "^7.4.4"
+                "@babel/helper-member-expression-to-functions": "^7.12.1",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.12.5",
+                "@babel/types": "^7.12.5"
             }
         },
-        "@babel/helpers": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-            "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+        "@babel/helper-simple-access": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+            "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
             "requires": {
-                "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/types": "^7.12.1"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+            "requires": {
+                "@babel/types": "^7.11.0"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+        },
+        "@babel/helpers": {
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+            "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+            "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.12.5",
+                "@babel/types": "^7.12.5"
             }
         },
         "@babel/highlight": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
@@ -97,24 +183,32 @@
             }
         },
         "@babel/parser": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-            "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+            "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg=="
+        },
+        "@babel/plugin-syntax-decorators": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz",
+            "integrity": "sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
         },
         "@babel/plugin-syntax-jsx": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
-            "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
+            "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-typescript": {
-            "version": "7.3.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
-            "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
+            "integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/runtime": {
@@ -127,38 +221,78 @@
             }
         },
         "@babel/template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.12.7",
+                "@babel/types": "^7.12.7"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                }
             }
         },
         "@babel/traverse": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-            "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+            "version": "7.12.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+            "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.4",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/parser": "^7.4.5",
-                "@babel/types": "^7.4.4",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.12.5",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.12.7",
+                "@babel/types": "^7.12.7",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.11"
+                "lodash": "^4.17.19"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "requires": {
+                        "@babel/highlight": "^7.10.4"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                }
             }
         },
         "@babel/types": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-            "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+            "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.11",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -764,9 +898,9 @@
             "dev": true
         },
         "convert-source-map": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
             "requires": {
                 "safe-buffer": "~5.1.1"
             }
@@ -811,11 +945,11 @@
             "dev": true
         },
         "debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
             }
         },
         "decamelize": {
@@ -955,7 +1089,8 @@
         "esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -1213,6 +1348,11 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
+        },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -1947,11 +2087,11 @@
             "dev": true
         },
         "json5": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+            "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "^1.2.5"
             }
         },
         "jsprim": {
@@ -3346,11 +3486,6 @@
                 }
             }
         },
-        "trim-right": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-        },
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -3415,9 +3550,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.9.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
             "dev": true
         },
         "union-value": {

--- a/package.json
+++ b/package.json
@@ -105,10 +105,11 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0-beta.54",
-    "@babel/parser": "^7.0.0-beta.54",
-    "@babel/plugin-syntax-jsx": "^7.0.0-beta.54",
-    "@babel/plugin-syntax-typescript": "^7.0.0-beta.54"
+    "@babel/core": "^7.12.9",
+    "@babel/parser": "^7.12.7",
+    "@babel/plugin-syntax-decorators": "^7.12.1",
+    "@babel/plugin-syntax-jsx": "^7.12.1",
+    "@babel/plugin-syntax-typescript": "^7.12.1"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
@@ -119,7 +120,7 @@
     "prettier": "1.13.7",
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.13.0",
-    "typescript": "^2.6.1",
+    "typescript": "^3",
     "vscode": "^1.1.6"
   }
 }

--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -5,11 +5,12 @@ const testTokens = ["suite", "describe", "context", "it", "specify", "test"];
 function codeParser(sourceCode) {
   const parserOptions: ParserOptions = {
     plugins: [
-      "jsx",
       "typescript",
-      "objectRestSpread",
-      "optionalChaining",
-      "nullishCoalescingOperator"
+      ["decorators", { decoratorsBeforeExport: false }],
+      "classPrivateMethods",
+      "classPrivateProperties",
+      "topLevelAwait",
+      "jsx"
     ],
     sourceType: "module",
     tokens: true

--- a/src/test/parser/codeParser.test.ts
+++ b/src/test/parser/codeParser.test.ts
@@ -52,6 +52,33 @@ suite("codeParser Tests", () => {
     assert.equal(2, codeParser(code).length);
   });
 
+  test("Decorator syntax", () => {
+    const code = `
+      describe("TestWithOptionalChaining", () => {
+        it("just works", () => {
+          type OptionalParams = {
+            name?: string;
+            catchphrase?: string;
+          }
+          function decorator(target: any) {
+            void 0
+          }
+          @decorator
+          class Obj {
+            name: string
+            constructor({ name, catchPhrase }: OptionalParams = { name: 'Testify' }){
+              this.name = name
+            }
+          }
+          const newObject = new Obj();
+          expect(newObject?.name).to.be.equal('Testify');
+          expect(newObject?.catchphrase).toBeUndefined();
+        })
+      })`;
+
+    assert.equal(2, codeParser(code).length);
+  });
+
   test("Rest Spread syntax", () => {
     const code = `
         describe("TestWithRestSpread", () => {


### PR DESCRIPTION
Using the `{ decoratorsBeforeExport: false }` Option -- This is currently contrary to the `experimentalDecorators` flag in typescript, however it is the direction of the proposal which has undergone much discussion. 

It shouldn't matter a whole lot for purposes of maintaining a codelens -- as users are not normally `export`ing from tests.

closes #60 

Updated babel+ to support syntax currently available in newer v8 versions
Updated typescript