### PR TITLE
feat(runner): tap t.test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,17 @@ Testify is a JavaScript and Typescript test runner extension for VSCode. It adds
 -   `it`,
 -   `specify`
 -   `test`
+-   `t.test`
 
 enabling VSCode to run associated tests and output the results in the integrated terminal.
-Currently it works **out of the box** for **Mocha** and **Jest** test runner.
+## Compatibility
+
+This extension works currently with:
+
+-   Mocha
+-   Jest
+-   AVA
+-   Tap
 
 ## Demo
 
@@ -34,14 +42,6 @@ The following configuration properties are available:
 | `testify.envVars`        | Environment variables to set before running a test | { "NODE_ENV": "test" }        |
 | `testify.skipFiles`      | Array of glob patterns for script paths to skip    | ["<node_internals>/**/*.js"]  |
 | `testify.testRunnerPath` | Path to test runner                                | "src/node_modules/.bin/mocha" |
-
-## Compatibility
-
-This extension works currently with :
-
--   Mocha
--   Jest
--   AVA
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,71 +13,78 @@
                 "@babel/highlight": "^7.0.0"
             }
         },
+        "@babel/compat-data": {
+            "version": "7.13.15",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+            "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
+        },
         "@babel/core": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
-            "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+            "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
             "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.12.10",
-                "@babel/helper-module-transforms": "^7.12.1",
-                "@babel/helpers": "^7.12.5",
-                "@babel/parser": "^7.12.10",
-                "@babel/template": "^7.12.7",
-                "@babel/traverse": "^7.12.10",
-                "@babel/types": "^7.12.10",
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.13.16",
+                "@babel/helper-compilation-targets": "^7.13.16",
+                "@babel/helper-module-transforms": "^7.13.14",
+                "@babel/helpers": "^7.13.16",
+                "@babel/parser": "^7.13.16",
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.13.15",
+                "@babel/types": "^7.13.16",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.1",
+                "gensync": "^1.0.0-beta.2",
                 "json5": "^2.1.2",
-                "lodash": "^4.17.19",
-                "semver": "^5.4.1",
+                "semver": "^6.3.0",
                 "source-map": "^0.5.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+                    "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
                     "requires": {
-                        "@babel/highlight": "^7.10.4"
+                        "@babel/highlight": "^7.12.13"
                     }
                 },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
                 "@babel/highlight": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "version": "7.13.10",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+                    "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "@babel/helper-validator-identifier": "^7.12.11",
                         "chalk": "^2.0.0",
                         "js-tokens": "^4.0.0"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
                         "to-fast-properties": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "@babel/helper-validator-identifier": {
-                            "version": "7.12.11",
-                            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-                            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-                        }
                     }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
         },
         "@babel/generator": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-            "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+            "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
             "requires": {
-                "@babel/types": "^7.12.11",
+                "@babel/types": "^7.13.16",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -88,25 +95,54 @@
                     "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
                         "to-fast-properties": "^2.0.0"
                     }
                 }
             }
         },
-        "@babel/helper-function-name": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-            "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+        "@babel/helper-compilation-targets": {
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+            "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
             "requires": {
-                "@babel/helper-get-function-arity": "^7.12.10",
-                "@babel/template": "^7.12.7",
-                "@babel/types": "^7.12.11"
+                "@babel/compat-data": "^7.13.15",
+                "@babel/helper-validator-option": "^7.12.17",
+                "browserslist": "^4.14.5",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+            "integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
+            "requires": {
+                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-member-expression-to-functions": "^7.13.0",
+                "@babel/helper-optimise-call-expression": "^7.12.13",
+                "@babel/helper-replace-supers": "^7.13.0",
+                "@babel/helper-split-export-declaration": "^7.12.13"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+            "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.12.13",
+                "@babel/template": "^7.12.13",
+                "@babel/types": "^7.12.13"
             },
             "dependencies": {
                 "@babel/helper-validator-identifier": {
@@ -115,23 +151,22 @@
                     "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
                         "to-fast-properties": "^2.0.0"
                     }
                 }
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-            "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+            "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
             "requires": {
-                "@babel/types": "^7.12.10"
+                "@babel/types": "^7.12.13"
             },
             "dependencies": {
                 "@babel/helper-validator-identifier": {
@@ -140,55 +175,22 @@
                     "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
                         "to-fast-properties": "^2.0.0"
                     }
                 }
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.12.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
-            "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+            "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
             "requires": {
-                "@babel/types": "^7.12.7"
-            }
-        },
-        "@babel/helper-module-imports": {
-            "version": "7.12.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-            "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
-            "requires": {
-                "@babel/types": "^7.12.5"
-            }
-        },
-        "@babel/helper-module-transforms": {
-            "version": "7.12.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-            "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
-            "requires": {
-                "@babel/helper-module-imports": "^7.12.1",
-                "@babel/helper-replace-supers": "^7.12.1",
-                "@babel/helper-simple-access": "^7.12.1",
-                "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.12.1",
-                "@babel/types": "^7.12.1",
-                "lodash": "^4.17.19"
-            }
-        },
-        "@babel/helper-optimise-call-expression": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
-            "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
-            "requires": {
-                "@babel/types": "^7.12.10"
+                "@babel/types": "^7.13.12"
             },
             "dependencies": {
                 "@babel/helper-validator-identifier": {
@@ -197,31 +199,109 @@
                     "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+            "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+            "requires": {
+                "@babel/types": "^7.13.12"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
+                "@babel/types": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.12.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.13.14",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+            "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.13.12",
+                "@babel/helper-replace-supers": "^7.13.12",
+                "@babel/helper-simple-access": "^7.13.12",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/helper-validator-identifier": "^7.12.11",
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.13.13",
+                "@babel/types": "^7.13.14"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
+                "@babel/types": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.12.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+            "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+            "requires": {
+                "@babel/types": "^7.12.13"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
+                "@babel/types": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.12.11",
                         "to-fast-properties": "^2.0.0"
                     }
                 }
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-            "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+            "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
         },
         "@babel/helper-replace-supers": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
-            "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+            "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.12.7",
-                "@babel/helper-optimise-call-expression": "^7.12.10",
-                "@babel/traverse": "^7.12.10",
-                "@babel/types": "^7.12.11"
+                "@babel/helper-member-expression-to-functions": "^7.13.12",
+                "@babel/helper-optimise-call-expression": "^7.12.13",
+                "@babel/traverse": "^7.13.0",
+                "@babel/types": "^7.13.12"
             },
             "dependencies": {
                 "@babel/helper-validator-identifier": {
@@ -230,31 +310,22 @@
                     "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
                         "to-fast-properties": "^2.0.0"
                     }
                 }
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.12.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-            "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+            "version": "7.13.12",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+            "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
             "requires": {
-                "@babel/types": "^7.12.1"
-            }
-        },
-        "@babel/helper-split-export-declaration": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-            "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-            "requires": {
-                "@babel/types": "^7.12.11"
+                "@babel/types": "^7.13.12"
             },
             "dependencies": {
                 "@babel/helper-validator-identifier": {
@@ -263,12 +334,35 @@
                     "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+            "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+            "requires": {
+                "@babel/types": "^7.12.13"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
+                "@babel/types": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.12.11",
                         "to-fast-properties": "^2.0.0"
                     }
                 }
@@ -277,16 +371,38 @@
         "@babel/helper-validator-identifier": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+            "dev": true
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.12.17",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+            "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
         },
         "@babel/helpers": {
-            "version": "7.12.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-            "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+            "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
             "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.12.5",
-                "@babel/types": "^7.12.5"
+                "@babel/template": "^7.12.13",
+                "@babel/traverse": "^7.13.17",
+                "@babel/types": "^7.13.17"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
+                "@babel/types": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.12.11",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/highlight": {
@@ -301,32 +417,41 @@
             }
         },
         "@babel/parser": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-            "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+            "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw=="
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
+            "integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.13.0",
+                "@babel/helper-plugin-utils": "^7.13.0"
+            }
         },
         "@babel/plugin-syntax-decorators": {
-            "version": "7.12.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz",
-            "integrity": "sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz",
+            "integrity": "sha512-Rw6aIXGuqDLr6/LoBBYE57nKOzQpz/aDkKlMqEwH+Vp0MXbG6H/TfRjaY343LKxzAKAMXIHsQ8JzaZKuDZ9MwA==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.12.13"
             }
         },
         "@babel/plugin-syntax-jsx": {
-            "version": "7.12.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
-            "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
+            "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.12.13"
             }
         },
         "@babel/plugin-syntax-typescript": {
-            "version": "7.12.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
-            "integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
+            "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.12.13"
             }
         },
         "@babel/runtime": {
@@ -339,107 +464,94 @@
             }
         },
         "@babel/template": {
-            "version": "7.12.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+            "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
             "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.12.7",
-                "@babel/types": "^7.12.7"
+                "@babel/code-frame": "^7.12.13",
+                "@babel/parser": "^7.12.13",
+                "@babel/types": "^7.12.13"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-                    "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+                    "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
                     "requires": {
-                        "@babel/highlight": "^7.10.4"
+                        "@babel/highlight": "^7.12.13"
                     }
                 },
+                "@babel/helper-validator-identifier": {
+                    "version": "7.12.11",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+                },
                 "@babel/highlight": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "version": "7.13.10",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+                    "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "@babel/helper-validator-identifier": "^7.12.11",
                         "chalk": "^2.0.0",
                         "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.12.11",
+                        "to-fast-properties": "^2.0.0"
                     }
                 }
             }
         },
         "@babel/traverse": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-            "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+            "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
             "requires": {
-                "@babel/code-frame": "^7.12.11",
-                "@babel/generator": "^7.12.11",
-                "@babel/helper-function-name": "^7.12.11",
-                "@babel/helper-split-export-declaration": "^7.12.11",
-                "@babel/parser": "^7.12.11",
-                "@babel/types": "^7.12.12",
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.13.16",
+                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/parser": "^7.13.16",
+                "@babel/types": "^7.13.17",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.19"
+                "globals": "^11.1.0"
             },
             "dependencies": {
                 "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+                    "version": "7.12.13",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+                    "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
                     "requires": {
-                        "@babel/highlight": "^7.10.4"
+                        "@babel/highlight": "^7.12.13"
                     }
                 },
-                "@babel/generator": {
+                "@babel/helper-validator-identifier": {
                     "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-                    "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
-                    "requires": {
-                        "@babel/types": "^7.12.11",
-                        "jsesc": "^2.5.1",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-                    "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
-                    "requires": {
-                        "@babel/types": "^7.12.11"
-                    }
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+                    "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
                 },
                 "@babel/highlight": {
-                    "version": "7.10.4",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-                    "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+                    "version": "7.13.10",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+                    "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
                     "requires": {
-                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "@babel/helper-validator-identifier": "^7.12.11",
                         "chalk": "^2.0.0",
                         "js-tokens": "^4.0.0"
                     }
                 },
-                "@babel/parser": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-                    "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
-                },
                 "@babel/types": {
-                    "version": "7.12.12",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-                    "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+                    "version": "7.13.17",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+                    "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
                     "requires": {
                         "@babel/helper-validator-identifier": "^7.12.11",
-                        "lodash": "^4.17.19",
                         "to-fast-properties": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "@babel/helper-validator-identifier": {
-                            "version": "7.12.11",
-                            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-                            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-                        }
                     }
                 }
             }
@@ -448,6 +560,7 @@
             "version": "7.12.7",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
             "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "lodash": "^4.17.19",
@@ -462,6 +575,12 @@
             "requires": {
                 "any-observable": "^0.3.0"
             }
+        },
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
         },
         "@types/babel__traverse": {
             "version": "7.11.0",
@@ -498,12 +617,12 @@
             "dev": true
         },
         "agent-base": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "dev": true,
             "requires": {
-                "es6-promisify": "^5.0.0"
+                "debug": "4"
             }
         },
         "ajv": {
@@ -814,10 +933,22 @@
             }
         },
         "browser-stdout": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
+        },
+        "browserslist": {
+            "version": "4.16.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+            "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
+            "requires": {
+                "caniuse-lite": "^1.0.30001214",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.719",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+            }
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -877,6 +1008,11 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001214",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+            "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg=="
         },
         "caseless": {
             "version": "0.12.0",
@@ -1050,6 +1186,11 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
+        "colorette": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1219,6 +1360,11 @@
                 "safer-buffer": "^2.1.0"
             }
         },
+        "electron-to-chromium": {
+            "version": "1.3.720",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
+            "integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw=="
+        },
         "elegant-spinner": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -1254,6 +1400,11 @@
             "requires": {
                 "es6-promise": "^4.0.3"
             }
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -1581,9 +1732,9 @@
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         },
         "growl": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
         "har-schema": {
@@ -1663,30 +1814,14 @@
             "dev": true
         },
         "http-proxy-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
             "dev": true,
             "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
             }
         },
         "http-signature": {
@@ -1701,24 +1836,13 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
             "dev": true,
             "requires": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                }
+                "agent-base": "6",
+                "debug": "4"
             }
         },
         "husky": {
@@ -2267,9 +2391,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-            "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
             "requires": {
                 "minimist": "^1.2.5"
             }
@@ -2509,7 +2633,8 @@
         "lodash": {
             "version": "4.17.19",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+            "dev": true
         },
         "log-symbols": {
             "version": "2.2.0",
@@ -2670,27 +2795,28 @@
             }
         },
         "mocha": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
             "dev": true,
             "requires": {
-                "browser-stdout": "1.3.0",
-                "commander": "2.11.0",
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
                 "debug": "3.1.0",
-                "diff": "3.3.1",
+                "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
                 "glob": "7.1.2",
-                "growl": "1.10.3",
+                "growl": "1.10.5",
                 "he": "1.1.1",
+                "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
-                "supports-color": "4.4.0"
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "version": "2.15.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
                 "debug": {
@@ -2701,12 +2827,6 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
-                },
-                "diff": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-                    "dev": true
                 },
                 "glob": {
                     "version": "7.1.2",
@@ -2721,12 +2841,6 @@
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
                     }
-                },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
                 },
                 "minimist": {
                     "version": "0.0.8",
@@ -2750,12 +2864,12 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -2789,6 +2903,11 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
             }
+        },
+        "node-releases": {
+            "version": "1.1.71",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
         },
         "normalize-path": {
             "version": "1.0.0",
@@ -3071,12 +3190,6 @@
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
-        "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-            "dev": true
-        },
         "regenerator-runtime": {
             "version": "0.13.7",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
@@ -3143,12 +3256,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
-        },
-        "requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
         },
         "resolve": {
@@ -3226,7 +3333,8 @@
         "semver": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "dev": true
         },
         "semver-compare": {
             "version": "1.0.0",
@@ -3868,16 +3976,6 @@
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
             "dev": true
         },
-        "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-            "dev": true,
-            "requires": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
-            }
-        },
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -3902,17 +4000,17 @@
             }
         },
         "vscode": {
-            "version": "1.1.34",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.34.tgz",
-            "integrity": "sha512-GuT3tCT2N5Qp26VG4C+iGmWMgg/MuqtY5G5TSOT3U/X6pgjM9LFulJEeqpyf6gdzpI4VyU3ZN/lWPo54UFPuQg==",
+            "version": "1.1.37",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+            "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2",
-                "mocha": "^4.0.1",
-                "request": "^2.88.0",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "mocha": "^5.2.0",
                 "semver": "^5.4.1",
                 "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.4",
                 "vscode-test": "^0.4.1"
             }
         },
@@ -3924,6 +4022,52 @@
             "requires": {
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.1"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+                    "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+                    "dev": true,
+                    "requires": {
+                        "es6-promisify": "^5.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "http-proxy-agent": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+                    "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "4",
+                        "debug": "3.1.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+                    "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -105,12 +105,13 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
-    "@babel/core": "^7.12.10",
-    "@babel/parser": "^7.12.11",
-    "@babel/plugin-syntax-decorators": "^7.12.1",
-    "@babel/plugin-syntax-jsx": "^7.12.1",
-    "@babel/plugin-syntax-typescript": "^7.12.1",
-    "@babel/traverse": "^7.12.12"
+    "@babel/core": "^7.13.16",
+    "@babel/parser": "^7.13.16",
+    "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-syntax-decorators": "^7.12.13",
+    "@babel/plugin-syntax-jsx": "^7.12.13",
+    "@babel/plugin-syntax-typescript": "^7.12.13",
+    "@babel/traverse": "^7.13.17"
   },
   "devDependencies": {
     "@types/babel__traverse": "^7.11.0",
@@ -124,6 +125,6 @@
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.13.0",
     "typescript": "^3",
-    "vscode": "^1.1.6"
+    "vscode": "^1.1.37"
   }
 }

--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -33,7 +33,6 @@ function codeParser(sourceCode) {
         // Callee is a direct call to a test function
         identifier = node.callee;
       } else if (node.callee.type === "MemberExpression") {
-        //
         if (
           node.callee.property.type === "Identifier" &&
           testTokens.includes(node.callee.property.name)
@@ -41,6 +40,11 @@ function codeParser(sourceCode) {
           // Callee seems to be a test function. Check if known parent object
           // is present
           if (
+            node.callee.object.type === "Identifier" &&
+            node.callee.object.name === "t"
+          ) {
+            identifier = node.callee.property;
+          } else if (
             node.callee.object.type === "CallExpression" &&
             node.callee.object.callee.type === "Identifier" &&
             parentTokens.includes(node.callee.object.callee.name)

--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -10,6 +10,7 @@ function codeParser(sourceCode) {
     plugins: [
       "typescript",
       ["decorators", { decoratorsBeforeExport: false }],
+      "classProperties",
       "classPrivateMethods",
       "classPrivateProperties",
       "topLevelAwait",

--- a/src/runners/TapTestRunner.ts
+++ b/src/runners/TapTestRunner.ts
@@ -1,0 +1,75 @@
+import { join } from "path";
+import { debug, WorkspaceFolder } from "vscode";
+import { ITestRunnerInterface } from "../interfaces/ITestRunnerInterface";
+import { ConfigurationProvider } from "../providers/ConfigurationProvider";
+import { TerminalProvider } from "../providers/TerminalProvider";
+
+// TODO: Make a more generic test runner class and extend it
+export class TapTestRunner implements ITestRunnerInterface {
+  public name: string = "tap";
+  public path: string = join("node_modules", ".bin", this.name);
+  public terminalProvider: TerminalProvider = null;
+  public configurationProvider: ConfigurationProvider = null;
+
+  constructor(
+    configurationProvider: ConfigurationProvider,
+    terminalProvider: TerminalProvider,
+    path?: string
+  ) {
+    this.terminalProvider = terminalProvider;
+    this.configurationProvider = configurationProvider;
+
+    if (path) {
+      this.path = path;
+    }
+  }
+
+  public runTest(
+    rootPath: WorkspaceFolder,
+    fileName: string,
+    testName: string
+  ) {
+    const additionalArguments = this.configurationProvider.additionalArguments;
+    const environmentVariables = this.configurationProvider
+      .environmentVariables;
+
+    const command = `${
+      this.path
+    } ${fileName} --grep="${testName}" ${additionalArguments}`.trim();
+
+    const terminal = this.terminalProvider.get(
+      { env: environmentVariables },
+      rootPath
+    );
+
+    terminal.sendText(command, true);
+    terminal.show(true);
+  }
+
+  public debugTest(
+    rootPath: WorkspaceFolder,
+    fileName: string,
+    testName: string
+  ) {
+    const additionalArguments = this.configurationProvider.additionalArguments;
+    const environmentVariables = this.configurationProvider
+      .environmentVariables;
+    const skipFiles = this.configurationProvider.skipFiles;
+
+    debug.startDebugging(rootPath, {
+      args: [
+        fileName,
+        "--grep",
+        testName,
+        ...additionalArguments.split(" ")
+      ].filter(x => x),
+      console: "integratedTerminal",
+      env: environmentVariables,
+      name: "Debug Test",
+      program: join(rootPath.uri.fsPath, this.path),
+      request: "launch",
+      skipFiles,
+      type: "node"
+    });
+  }
+}

--- a/src/runners/TestRunnerFactory.ts
+++ b/src/runners/TestRunnerFactory.ts
@@ -9,6 +9,7 @@ import { TerminalProvider } from "../providers/TerminalProvider";
 import { AvaTestRunner } from "./AvaTestRunner";
 import { JestTestRunner } from "./JestTestRunner";
 import { MochaTestRunner } from "./MochaTestRunner";
+import { TapTestRunner } from "./TapTestRunner";
 
 const terminalProvider = new TerminalProvider();
 
@@ -84,6 +85,12 @@ export async function getTestRunner(
         terminalProvider,
         customTestRunnerPath
       );
+    } else if (customTestRunnerName === "tap") {
+      return new TapTestRunner(
+        configurationProvider,
+        terminalProvider,
+        customTestRunnerPath
+      );
     }
   }
 
@@ -99,9 +106,13 @@ export async function getTestRunner(
     configurationProvider,
     terminalProvider
   );
+  const tapTestRunner = new TapTestRunner(
+    configurationProvider,
+    terminalProvider
+  );
 
   return getAvailableTestRunner(
-    [jestTestRunner, mochaTestRunner, avaTestRunner],
+    [jestTestRunner, mochaTestRunner, avaTestRunner, tapTestRunner],
     rootPath
   );
 }

--- a/src/test/parser/codeParser.test.ts
+++ b/src/test/parser/codeParser.test.ts
@@ -172,6 +172,20 @@ suite("codeParser Tests", () => {
     assert.equal("each", p[1].loc.identifierName);
   });
 
+  test("tap tests with t.test", () => {
+    const code = `
+      t.test('some suite', (t) => {
+        t.equal(1,1, 'they should be equal')
+      })
+      t.test('some other suite', (t) => {
+        t.equal(1,1, 'they should be equal')
+      })
+    `;
+    const p = codeParser(code);
+    assert.equal(2, p.length);
+    assert.equal("some suite", p[0].testName);
+  });
+
   test("is not triggered by regex test #32", () => {
     const code = `
       describe("TestWithNullishCoalescing", () => {

--- a/src/test/parser/codeParser.test.ts
+++ b/src/test/parser/codeParser.test.ts
@@ -64,6 +64,7 @@ suite("codeParser Tests", () => {
           }
           @decorator
           class Obj {
+            property = true
             name: string
             constructor({ name, catchPhrase }: OptionalParams = { name: 'Testify' }){
               this.name = name


### PR DESCRIPTION
### Description

This adds support for [tap](https://node-tap.org) - via `t.test(` detection and language support for class properties (stage 3 - available in v8/node)

![image](https://user-images.githubusercontent.com/5818726/115882568-7c7f0d80-a412-11eb-96cc-59749df74f05.png)


TODO:
 - track sub-test names for ordered passing to `tap -g` (support nested sub-tests)