### PR TITLE
build: add missing VSCE_PAT env variable

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -25,3 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}


### PR DESCRIPTION
### Description

Add missing VSCE_PAT env variable to semantic release action in the "Continuous Deployment" workflow