### PR TITLE
build: specify version of vsce plugin

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -21,7 +21,7 @@ jobs:
             @semantic-release/npm@9
             @semantic-release/git@10
             @semantic-release/github@8
-            semantic-release-vsce@5
+            semantic-release-vsce@5.0.14
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.6.2",
         "semantic-release": "^19.0.2",
-        "semantic-release-vsce": "^5.0.15",
+        "semantic-release-vsce": "^5.0.14",
         "ts-node": "^10.8.0",
         "typescript": "^4.7.2",
         "webpack": "^5.72.1",
@@ -11090,9 +11090,9 @@
       }
     },
     "node_modules/semantic-release-vsce": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/semantic-release-vsce/-/semantic-release-vsce-5.0.15.tgz",
-      "integrity": "sha512-OQQ2rVJmuWxM/TUTG1g9WmkK/D0QU2TJIIqHehctTLiDShd4UqOxf4aRyYPW258ij7yjH7Q+frSucu1ITNep4Q==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/semantic-release-vsce/-/semantic-release-vsce-5.0.14.tgz",
+      "integrity": "sha512-NpqWrG36rvOP8fR/Z7pcZeMClBZ3cjrOb6Ua/nuNXmFrc095jg5oESLzUkrncjBENsuLGTUGY1on+C1CX9BWnQ==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
@@ -21085,9 +21085,9 @@
       }
     },
     "semantic-release-vsce": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/semantic-release-vsce/-/semantic-release-vsce-5.0.15.tgz",
-      "integrity": "sha512-OQQ2rVJmuWxM/TUTG1g9WmkK/D0QU2TJIIqHehctTLiDShd4UqOxf4aRyYPW258ij7yjH7Q+frSucu1ITNep4Q==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/semantic-release-vsce/-/semantic-release-vsce-5.0.14.tgz",
+      "integrity": "sha512-NpqWrG36rvOP8fR/Z7pcZeMClBZ3cjrOb6Ua/nuNXmFrc095jg5oESLzUkrncjBENsuLGTUGY1on+C1CX9BWnQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
     "semantic-release": "^19.0.2",
-    "semantic-release-vsce": "^5.0.15",
+    "semantic-release-vsce": "^5.0.14",
     "ts-node": "^10.8.0",
     "typescript": "^4.7.2",
     "webpack": "^5.72.1",


### PR DESCRIPTION
### Description

It seems like the current version (5.0.15) of the vsce plugin for the semantic release is not working properly with the VSCE PAT.